### PR TITLE
More Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ My personal configuration settings for both **bash** and **zsh** shells.
    ./install.sh
    ```
 
-3. Switch to zsh (optional but recommended):
+3. **If you had previous git completion issues**, clean up:
+   ```bash
+   rm -f ~/.git-completion.zsh
+   ```
+
+4. Switch to zsh (if necessary):
    ```bash
    chsh -s $(which zsh)
    ```
@@ -54,10 +59,10 @@ hostname:/current/path (git-branch) [💩] $
 ```
 
 **Colors:**
-- **Hostname**: Dark orange (256-color: 166)
+- **Hostname**: Medium grey (256-color: 244)
 - **Path**: Lavender purple (256-color: 141)
-- **Git branch**: Medium grey (256-color: 244)
-- **Dirty indicator**: Light orange/peach (256-color: 216)
+- **Git branch**: Dark orange (256-color: 166)
+- **Dirty indicator**: Deep orange (256-color: 202)
 
 The **💩 emoji** appears when you have uncommitted git changes.
 
@@ -88,10 +93,10 @@ Edit `/system/.prompt` and modify the color codes:
 
 ```bash
 # For zsh (256-color format)
-PROMPT='%F{166}%m%f:%F{141}%~%f%F{244}$vcs_info_msg_0_%f%F{216}$(__git_dirty)%f $ '
+PROMPT='%F{244}%m%f:%F{141}%~%f%F{166}$vcs_info_msg_0_%f%F{202}$(__git_dirty)%f $ '
 
 # For bash (256-color format)
-PS1="\[\033[38;5;166m\]\h\[\033[0m\]:\[\033[38;5;141m\]\w\[\033[38;5;244m\]\$(__git_branch)\[\033[38;5;216m\]\$(__git_dirty)\[\033[0m\] $ "
+PS1="\[\033[38;5;244m\]\h\[\033[0m\]:\[\033[38;5;141m\]\w\[\033[38;5;166m\]\$(__git_branch)\[\033[38;5;202m\]\$(__git_dirty)\[\033[0m\] $ "
 ```
 
 ### Adding Custom Aliases

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 # Download git completions for bash
-curl https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash -o ~/.git-completion.bash
+curl -s https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash -o ~/.git-completion.bash
 
-# Download git completions for zsh (if zsh is available)
-if command -v zsh >/dev/null 2>&1; then
-  curl https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.zsh -o ~/.git-completion.zsh
-fi
+# For zsh, we'll rely on built-in git completion instead of downloading
+# The downloaded zsh completion file often causes conflicts
+echo "Zsh will use built-in git completion (no download needed)"
 
 
 # Absolute path of dotfiles directory

--- a/system/.completion
+++ b/system/.completion
@@ -4,8 +4,13 @@ if [ -n "$ZSH_VERSION" ]; then
   # Zsh completions
   autoload -U compinit && compinit
   
-  # Load git completions for zsh if available
-  [ -f ~/.git-completion.zsh ] && source ~/.git-completion.zsh
+  # For zsh, git completion is usually built-in or handled by oh-my-zsh
+  # If you have a custom git completion, load it properly:
+  if [ -f ~/.git-completion.zsh ]; then
+    # Rename to _git and place in fpath, or use zsh's built-in git completion
+    fpath=(~/.zsh $fpath)
+    autoload -U _git
+  fi
   
   # Enable zsh completion features
   setopt AUTO_MENU

--- a/system/.prompt
+++ b/system/.prompt
@@ -1,7 +1,7 @@
 # Git prompt functions (shell-agnostic)
 function __git_dirty {
   git diff --quiet HEAD &>/dev/null
-  [ $? == 1 ] && echo " [💩]"
+  [ $? -eq 1 ] && echo " [💩]"
 }
 
 function __git_ps1 ()
@@ -65,7 +65,7 @@ if [ -n "$ZSH_VERSION" ]; then
   zstyle ':vcs_info:*' enable git
 
   # Zsh prompt with 256-color palette
-  PROMPT='%F{166}%m%f:%F{141}%~%f%F{244}$vcs_info_msg_0_%f%F{216}$(__git_dirty)%f $ '
+  PROMPT='%F{244}%m%f:%F{141}%~%f%F{166}$vcs_info_msg_0_%f%F{202}$(__git_dirty)%f $ '
 else
   # Bash prompt configuration
   bash_prompt() {
@@ -105,7 +105,7 @@ else
     [ $UID -eq "0" ] && UC=$R   # root's color
 
     # Bash prompt with 256-color palette
-    PS1="\[\033[38;5;166m\]\h\[\033[0m\]:\[\033[38;5;141m\]\w\[\033[38;5;244m\]\$(__git_branch)\[\033[38;5;216m\]\$(__git_dirty)\[\033[0m\] $ "
+    PS1="\[\033[38;5;244m\]\h\[\033[0m\]:\[\033[38;5;141m\]\w\[\033[38;5;166m\]\$(__git_branch)\[\033[38;5;202m\]\$(__git_dirty)\[\033[0m\] $ "
   }
 
   bash_prompt


### PR DESCRIPTION
### Git Completion Setup

* The `install.sh` script no longer downloads a separate git completion file for zsh, relying instead on zsh's built-in completion to avoid conflicts.
* In `system/.completion`, zsh users now use built-in or properly loaded custom git completions, with instructions to place custom completions in the correct location if needed.

### Prompt Appearance and Color Updates

* The prompt color scheme for both bash and zsh has been updated for consistency: hostname is now medium grey, git branch is dark orange, and the dirty indicator is deep orange. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R65) [[2]](diffhunk://#diff-047a4229790387ecd7b36c666591afc0f4ad3fe44016eb404ca9996eefe75298L68-R68) [[3]](diffhunk://#diff-047a4229790387ecd7b36c666591afc0f4ad3fe44016eb404ca9996eefe75298L108-R108) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R99)
* Documentation in `README.md` has been updated to reflect these color changes and clarify which color codes correspond to each prompt element. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R65) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R99)

### Setup Instructions and Documentation

* The `README.md` now includes a step to clean up any previous conflicting git completion files for zsh, ensuring a smoother setup process.

### Minor Fixes

* The `__git_dirty` function now uses a more robust syntax for checking git status in a shell-agnostic way.